### PR TITLE
Set the correct vscode engine compatibiltiy

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "version": "1.0.3",
     "publisher": "temilaj",
     "engines": {
-        "vscode": "^1.14.0"
+        "vscode": "^1.26.0"
     },
     "license": "MIT",
     "galleryBanner": {


### PR DESCRIPTION
vscode engine should be set to ^1.26 because older VS Code versions does not support extensionPack property

@temilaj Please have this change before publishing